### PR TITLE
Don't add codechecker tasks if not enabled

### DIFF
--- a/classes/codechecker.bbclass
+++ b/classes/codechecker.bbclass
@@ -87,8 +87,6 @@ if test x"${CODECHECKER_ENABLED}" = x"1"; then
 fi
 }
 
-addtask codecheckeranalyse
-
 do_codecheckerreport() {
 
 if test x"${CODECHECKER_ENABLED}" = x"1"; then
@@ -170,5 +168,3 @@ if test x"${CODECHECKER_ENABLED}" = x"1"; then
     fi
 fi
 }
-
-addtask codecheckerreport


### PR DESCRIPTION
It doesn't make sense to add the tasks if codechecker is not enabled.
This also has the advantage that it gives an error if somebody
tries to execute a codechecker task but codechecker is no enabled.

Signed-off-by: Pascal Bach <pascal.bach@siemens.com>