### PR TITLE
Replace distutils by setuptools

### DIFF
--- a/recipes-devtools/codechecker/codechecker_6.17.0.bb
+++ b/recipes-devtools/codechecker/codechecker_6.17.0.bb
@@ -10,7 +10,7 @@ SRC_URI[sha256sum] = "1affc5fc6b21749050e36530868583c672852a448fd07bc7a221eb1d7d
 
 PYPI_PACKAGE = "codechecker"
 
-inherit pypi distutils3-base
+inherit pypi setuptools3-base
 
 SRC_URI += " file://0001-Don-t-require-fix-version-of-dependancies.patch"
 


### PR DESCRIPTION
Recent bitbake throws a warning:
  distutils-common-base.bbclass is deprecated,
  please use setuptools3-base.bbclass instead